### PR TITLE
Fix for NOTICE emitted by Echo

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -35,8 +35,10 @@
 	"BeforePageDisplay": "EchoConnectorHooks::onBeforePageDisplay"
     },
 	"ResourceModules": {
-		"ext.echo.fixer": {
-			"scripts": "echo.loader.fixer.js",
+		"ext.bluespice.echoconnector.fixer": {
+			"scripts": [
+				"echo.loader.fixer.js"
+			],
 			"dependencies": [
 				"ext.echo.ui",
 				"ext.echo.ui.desktop"

--- a/includes/EchoConnectorHooks.php
+++ b/includes/EchoConnectorHooks.php
@@ -197,8 +197,8 @@ class EchoConnectorHooks {
 	 * @return boolean
 	 */
 	public static function onBeforePageDisplay( &$out, &$skin ) {
-		if( $out->getTitle() == SpecialPage::getTitleFor( "Notifications" ) ) {
-			$out->addModules( array( 'ext.echo.fixer' ) );
+		if( $out->getTitle()->isSpecial( "Notifications" ) ) {
+			$out->addModules( array( 'ext.bluespice.echoconnector.fixer' ) );
 		}
 		return true;
 	}


### PR DESCRIPTION
A RL module name prefixed with 'ext.echo' will be processed by
Echo/Hooks.php:67 [1] and tis code will emit a NOTICE then the
'scripts' field is not an array.

Also fixed title comparator issue. The module never got loaded
as the Title class does not overload the "equals" operator. Thus an
object comparison was made.

[1] https://github.com/wikimedia/mediawiki-extensions-Echo/blob/b87fa2f66f4816179c51d6c1398715f62b0227c2/Hooks.php#L67